### PR TITLE
Add article suggestion viewer

### DIFF
--- a/client/index.html
+++ b/client/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <title>Article Suggestions</title>
+  <style>
+    table { border-collapse: collapse; width: 100%; }
+    th, td { border: 1px solid #ccc; padding: 8px; }
+    tr:hover { background-color: #f0f0f0; cursor: pointer; }
+  </style>
+</head>
+<body>
+  <h1>Articles</h1>
+  <table id="articles-table">
+    <thead>
+      <tr>
+        <th>Title</th>
+        <th>Suggestions</th>
+      </tr>
+    </thead>
+    <tbody></tbody>
+  </table>
+
+  <div id="suggestions-section" style="display:none; margin-top:20px;">
+    <h2>Suggestions for <span id="article-title"></span></h2>
+    <table id="suggestions-table">
+      <thead>
+        <tr><th>Suggestion</th></tr>
+      </thead>
+      <tbody></tbody>
+    </table>
+  </div>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/client/script.js
+++ b/client/script.js
@@ -1,0 +1,28 @@
+async function loadArticles() {
+  const res = await fetch('/articles/with-suggestions');
+  const articles = await res.json();
+  const tbody = document.querySelector('#articles-table tbody');
+  tbody.innerHTML = '';
+  articles.forEach(article => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${article.title}</td><td>${article.suggestion_count}</td>`;
+    tr.addEventListener('click', () => loadSuggestions(article));
+    tbody.appendChild(tr);
+  });
+}
+
+async function loadSuggestions(article) {
+  const res = await fetch(`/articles/${article.id}/suggestions`);
+  const suggestions = await res.json();
+  const tbody = document.querySelector('#suggestions-table tbody');
+  tbody.innerHTML = '';
+  suggestions.forEach(s => {
+    const tr = document.createElement('tr');
+    tr.innerHTML = `<td>${s.suggestion}</td>`;
+    tbody.appendChild(tr);
+  });
+  document.querySelector('#article-title').textContent = article.title;
+  document.getElementById('suggestions-section').style.display = 'block';
+}
+
+loadArticles();

--- a/server.js
+++ b/server.js
@@ -1,18 +1,20 @@
 const express = require("express");
 const sqlite3 = require("sqlite3").verbose();
 const cors = require("cors");
+const path = require("path");
 
 const app = express();
 const PORT = 3001;
 
 app.use(cors());
+app.use(express.static(path.join(__dirname, "client")));
 
 const db = new sqlite3.Database("./articles.db");
+const reviewDb = new sqlite3.Database("./article_reviews.db");
 
-// Get all articles with their update status
+// Get raw articles
 app.get("/articles", (req, res) => {
   const query = `SELECT id, title, content FROM articles`;
-
   db.all(query, [], (err, rows) => {
     if (err) return res.status(500).json({ error: err.message });
     const safeRows = rows.map(row => ({
@@ -20,6 +22,27 @@ app.get("/articles", (req, res) => {
       title: String(row.title)
     }));
     res.json(safeRows);
+  });
+});
+
+// Get articles with suggestion counts
+app.get("/articles/with-suggestions", (req, res) => {
+  const query = `SELECT a.id, a.title, COUNT(r.id) as suggestion_count
+                 FROM articles a
+                 LEFT JOIN article_reviews r ON a.id = r.article_id
+                 GROUP BY a.id`;
+  db.all(query, [], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
+  });
+});
+
+// Get suggestions for a specific article
+app.get("/articles/:id/suggestions", (req, res) => {
+  const query = `SELECT suggestion FROM article_reviews WHERE article_id = ?`;
+  reviewDb.all(query, [req.params.id], (err, rows) => {
+    if (err) return res.status(500).json({ error: err.message });
+    res.json(rows);
   });
 });
 


### PR DESCRIPTION
## Summary
- add an HTML/JS client that lists articles and displays suggestions
- update server to expose endpoints for suggestion counts and per-article suggestions and serve the client

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_685038957188832bb2bdffabbc27447c